### PR TITLE
Password reset did not work with Hotfix 2013-12-10

### DIFF
--- a/Products/remember/pas/utils.py
+++ b/Products/remember/pas/utils.py
@@ -2,7 +2,6 @@ import logging
 from AccessControl import Unauthorized
 from zope.component.hooks import getSite
 from Products.CMFCore.utils import getToolByName
-from Products.ZCatalog.Catalog import CatalogSearchArgumentsMap
 from Products.PluggableAuthService.interfaces.plugins import IExtractionPlugin
 
 logger = logging.getLogger('Products.remember.pas.utils')
@@ -33,8 +32,10 @@ def getBrainsForEmail(context, email, request=None):
         return []
 
     kw = dict(getEmail=email)
-    args = CatalogSearchArgumentsMap(request, kw)
-    users = user_catalog.search(args)
+
+    # this was using search(), but need to switch to Catalog.searchResults()
+    # because incompatibility with CatalogSearchArgumentsMap and hotfix 20131210
+    users = user_catalog.searchResults(request, **kw)
 
     # Searching for joe@example.org also returns john-joe@example.org.
     # But here we only want exact matches.


### PR DESCRIPTION
If email as login portal option is turned on, the latest hotfix gave a traceback on mail password reset.

This is because it tries to give CatalogSearchArgumentsMap to catalog.search() function. Monkey-patched hotfix search function cannot handle this because it tries to call .copy() on CatalogSearchArgumentsMap (hotfix assumes normal request is passed).

According to the comments in hotfix the workaround seems to be using `catalog.searchResults()` instead of `catalog.search()`. From hotfix:

```
from DateTime import DateTime
from Products.CMFCore.permissions import AccessInactivePortalContent
from Products.CMFCore.utils import _checkPermission
from Products.CMFCore.utils import _getAuthenticatedUser
from Products.CMFPlone.CatalogTool import CatalogTool

orig_search = CatalogTool.search

def search(self, *args, **kw):
    """ Wrap search() the same way that searchResults() is """
    query = {}

    if args:
    query = args[0]
```

I performed manual test on this, as I did not get unit tests running (see another unrelated mail send issue regarding this). 

I am not aware of security implications between search() and searchResults() as I found API unclear. I have no deep Zope magic knowledge so please shoot me down if I am wrong.
