### PR TITLE
Test with Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python: 2.7
+sudo: false
+cache:
+  directories:
+  - eggs
+env:
+  matrix:
+    - PLONE_VERSION=4.3
+#    - PLONE_VERSION=5.0
+matrix:
+  fast_finish: true
+install:
+- sed -ie "s#test-4.x#test-$PLONE_VERSION.x#" buildout.cfg
+- python bootstrap.py
+- bin/buildout annotate
+- bin/buildout
+script:
+- bin/test

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.9.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Test with Travis.  [maurits]
 
 
 1.9.4 (2016-06-30)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -4,6 +4,7 @@ extensions =
     mr.developer
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-4.x.cfg
+    http://dist.plone.org/release/4.3.6/versions.cfg
 package-name = Products.remember
 test-eggs = Products.remember[test]
 


### PR DESCRIPTION
Use Plone 4.3.6 for now, as the tests pass with that locally.
On latest 4.3.x we get:

ValueError: The 'remove' keyword is not supported in toolset.xml. Failed to remove 'portal_memberdata' from required tools. Use an element 'forbidden' instead.

That should be fixed, but let's first get Travis running. I have enabled the hook on Travis.